### PR TITLE
Implement leaderboard backend

### DIFF
--- a/backend/server/cmd/server/main.go
+++ b/backend/server/cmd/server/main.go
@@ -50,6 +50,7 @@ func main() {
 	http.HandleFunc("/api/tasks", h.RequireAuth(h.HandleGetTasks))
 	http.HandleFunc("/api/tasks/accept", h.RequireAuth(h.HandleAcceptTask))
 	http.HandleFunc("/api/tasks/cancel", h.RequireAuth(h.HandleCancelTask))
+	http.HandleFunc("/api/leaderboard", h.HandleGetLeaderboard)
 
 	http.Handle("/uploads/", http.StripPrefix("/uploads/", http.FileServer(http.Dir(cfg.UploadDir)))) // serve uploaded images
 	// Serve the frontend static files

--- a/backend/server/internal/handlers/curl_commands.txt
+++ b/backend/server/internal/handlers/curl_commands.txt
@@ -69,3 +69,6 @@ curl -X POST http://localhost:8080/api/tasks/accept \
   get my tasks:
   curl -X GET "http://localhost:8080/api/tasks?my_tasks=true" \
     -b "auth_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NzY0MzkyNjAsImxvZ2luIjoidHBpbmFybGkiLCJ1c2VyX2lkIjoyM30.Dxua3MQl5KtQ9wvThwI6Oxl_oDhfZ1-Fi-WfhHOyzrY" | jq
+
+  get all-time leaderboard:
+  curl -X GET http://localhost:8080/api/leaderboard | jq

--- a/backend/server/internal/handlers/leaderboard.go
+++ b/backend/server/internal/handlers/leaderboard.go
@@ -14,7 +14,6 @@ func (h *Handler) HandleGetLeaderboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rankings, err := h.DB.GetLeaderboard()
-
 	if err != nil {
 		log.Printf("HandleGetLeaderboard: GetLeaderboard error: %v", err)
 		http.Error(w, "Failed to fetch leaderboard", http.StatusInternalServerError)
@@ -30,4 +29,3 @@ func (h *Handler) HandleGetLeaderboard(w http.ResponseWriter, r *http.Request) {
 		log.Printf("HandleGetLeaderboard: JSON Encode error: %v", err)
 	}
 }
-

--- a/backend/server/internal/handlers/leaderboard.go
+++ b/backend/server/internal/handlers/leaderboard.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"plantbee-backend/internal/models"
+)
+
+func (h *Handler) HandleGetLeaderboard(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	rankings, err := h.DB.GetLeaderboard()
+
+	if err != nil {
+		log.Printf("HandleGetLeaderboard: GetLeaderboard error: %v", err)
+		http.Error(w, "Failed to fetch leaderboard", http.StatusInternalServerError)
+		return
+	}
+
+	resp := models.LeaderboardResponse{
+		Rankings: rankings,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Printf("HandleGetLeaderboard: JSON Encode error: %v", err)
+	}
+}
+

--- a/backend/server/internal/handlers/leaderboard.go
+++ b/backend/server/internal/handlers/leaderboard.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+
 	"plantbee-backend/internal/models"
 )
 

--- a/backend/server/internal/models/user.go
+++ b/backend/server/internal/models/user.go
@@ -22,9 +22,6 @@ type LeaderboardEntry struct {
 	WaterCount int    `json:"water_count"`
 }
 
-
 type LeaderboardResponse struct {
 	Rankings []LeaderboardEntry `json:"rankings"`
 }
-
-

--- a/backend/server/internal/models/user.go
+++ b/backend/server/internal/models/user.go
@@ -13,3 +13,18 @@ type User struct {
 	WaterCount   int       `json:"water_count"`
 	CreatedAt    time.Time `json:"created_at"`
 }
+
+type LeaderboardEntry struct {
+	Rank       int    `json:"rank"`
+	UserID     int    `json:"user_id"`
+	IntraName  string `json:"intra_name"`
+	ImageURL   string `json:"image_url"`
+	WaterCount int    `json:"water_count"`
+}
+
+
+type LeaderboardResponse struct {
+	Rankings []LeaderboardEntry `json:"rankings"`
+}
+
+

--- a/backend/server/internal/storage/user_store.go
+++ b/backend/server/internal/storage/user_store.go
@@ -95,3 +95,34 @@ func (d *DB) DeleteUser(userID int) error {
 
 	return tx.Commit()
 }
+func (d *DB) GetLeaderboard() ([]models.LeaderboardEntry, error) {
+	query := `
+		SELECT id, login, COALESCE(image_url, ''), water_count as score
+		FROM users
+		WHERE water_count > 0
+		ORDER BY score DESC
+	`
+
+	rows, err := d.Query(query)
+
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var entries []models.LeaderboardEntry
+	rank := 1
+	for rows.Next() {
+		var e models.LeaderboardEntry
+		if err := rows.Scan(&e.UserID, &e.IntraName, &e.ImageURL, &e.WaterCount); err != nil {
+			return nil, err
+		}
+
+
+		e.Rank = rank
+		entries = append(entries, e)
+		rank++
+	}
+	return entries, nil
+}
+

--- a/backend/server/internal/storage/user_store.go
+++ b/backend/server/internal/storage/user_store.go
@@ -105,7 +105,6 @@ func (d *DB) GetLeaderboard() ([]models.LeaderboardEntry, error) {
 	`
 
 	rows, err := d.Query(query)
-
 	if err != nil {
 		return nil, err
 	}

--- a/backend/server/internal/storage/user_store.go
+++ b/backend/server/internal/storage/user_store.go
@@ -95,6 +95,7 @@ func (d *DB) DeleteUser(userID int) error {
 
 	return tx.Commit()
 }
+
 func (d *DB) GetLeaderboard() ([]models.LeaderboardEntry, error) {
 	query := `
 		SELECT id, login, COALESCE(image_url, ''), water_count as score
@@ -108,7 +109,7 @@ func (d *DB) GetLeaderboard() ([]models.LeaderboardEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var entries []models.LeaderboardEntry
 	rank := 1
@@ -117,12 +118,9 @@ func (d *DB) GetLeaderboard() ([]models.LeaderboardEntry, error) {
 		if err := rows.Scan(&e.UserID, &e.IntraName, &e.ImageURL, &e.WaterCount); err != nil {
 			return nil, err
 		}
-
-
 		e.Rank = rank
 		entries = append(entries, e)
 		rank++
 	}
 	return entries, nil
 }
-


### PR DESCRIPTION
Added GET /api/leaderboard endpoint returning all-time volunteer rankings.
Includes user rank, user_id, intra_name, image_url, and total water_count.
Rankings includes all types of completed tasks.
Updated curl_commands.txt for testing.